### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/build.go
+++ b/build.go
@@ -82,7 +82,7 @@ var (
 
 // die prints the message with fmt.Fprintf() to stderr and exits with an error
 // code.
-func die(message string, args ...interface{}) {
+func die(message string, args ...any) {
 	fmt.Fprintf(os.Stderr, message, args...)
 	os.Exit(1)
 }
@@ -102,7 +102,7 @@ func showUsage(output io.Writer) {
 	fmt.Fprintf(output, "         --goarm value   set GOARM for cross-compilation\n")
 }
 
-func verbosePrintf(message string, args ...interface{}) {
+func verbosePrintf(message string, args ...any) {
 	if !verbose {
 		return
 	}

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -650,7 +650,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 			return progressReporter.Error(item, err)
 		}
 
-		messageHandler := func(msg string, args ...interface{}) {
+		messageHandler := func(msg string, args ...any) {
 			if !gopts.JSON {
 				progressPrinter.P(msg, args...)
 			}

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -65,7 +65,7 @@ func init() {
 	cmdDebugExamine.Flags().BoolVar(&repairByte, "repair-byte", false, "try to repair broken blobs by trying bytes")
 }
 
-func prettyPrintJSON(wr io.Writer, item interface{}) error {
+func prettyPrintJSON(wr io.Writer, item any) error {
 	buf, err := json.MarshalIndent(item, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -85,7 +85,7 @@ func TestLsNodeJSON(t *testing.T) {
 		rtest.Equals(t, c.expect+"\n", buf.String())
 
 		// Sanity check: output must be valid JSON.
-		var v interface{}
+		var v any
 		err = json.NewDecoder(buf).Decode(&v)
 		rtest.OK(t, err)
 	}

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -172,7 +172,7 @@ func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	systemFuse.Debug = func(msg interface{}) {
+	systemFuse.Debug = func(msg any) {
 		debug.Log("fuse: %v", msg)
 	}
 

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -235,7 +235,7 @@ func clearLine(w int) string {
 }
 
 // Printf writes the message to the configured stdout stream.
-func Printf(format string, args ...interface{}) {
+func Printf(format string, args ...any) {
 	_, err := fmt.Fprintf(globalOptions.stdout, format, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
@@ -243,7 +243,7 @@ func Printf(format string, args ...interface{}) {
 }
 
 // Print writes the message to the configured stdout stream.
-func Print(args ...interface{}) {
+func Print(args ...any) {
 	_, err := fmt.Fprint(globalOptions.stdout, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
@@ -251,7 +251,7 @@ func Print(args ...interface{}) {
 }
 
 // Println writes the message to the configured stdout stream.
-func Println(args ...interface{}) {
+func Println(args ...any) {
 	_, err := fmt.Fprintln(globalOptions.stdout, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
@@ -259,21 +259,21 @@ func Println(args ...interface{}) {
 }
 
 // Verbosef calls Printf to write the message when the verbose flag is set.
-func Verbosef(format string, args ...interface{}) {
+func Verbosef(format string, args ...any) {
 	if globalOptions.verbosity >= 1 {
 		Printf(format, args...)
 	}
 }
 
 // Verboseff calls Printf to write the message when the verbosity is >= 2
-func Verboseff(format string, args ...interface{}) {
+func Verboseff(format string, args ...any) {
 	if globalOptions.verbosity >= 2 {
 		Printf(format, args...)
 	}
 }
 
 // Warnf writes the message to the configured stderr stream.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	_, err := fmt.Fprintf(globalOptions.stderr, format, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stderr: %v\n", err)
@@ -282,7 +282,7 @@ func Warnf(format string, args ...interface{}) {
 
 // Exitf uses Warnf to write the message and then terminates the process with
 // the given exit code.
-func Exitf(exitcode int, format string, args ...interface{}) {
+func Exitf(exitcode int, format string, args ...any) {
 	if !(strings.HasSuffix(format, "\n")) {
 		format += "\n"
 	}
@@ -550,7 +550,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 	return s, nil
 }
 
-func parseConfig(loc location.Location, opts options.Options) (interface{}, error) {
+func parseConfig(loc location.Location, opts options.Options) (any, error) {
 	// only apply options for a particular backend here
 	opts = opts.Extract(loc.Scheme)
 

--- a/cmd/restic/global_debug.go
+++ b/cmd/restic/global_debug.go
@@ -36,7 +36,7 @@ func init() {
 
 type fakeTestingTB struct{}
 
-func (fakeTestingTB) Logf(msg string, args ...interface{}) {
+func (fakeTestingTB) Logf(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, msg, args...)
 }
 

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -28,7 +28,7 @@ func init() {
 	pflag.Parse()
 }
 
-func die(f string, args ...interface{}) {
+func die(f string, args ...any) {
 	if !strings.HasSuffix(f, "\n") {
 		f += "\n"
 	}
@@ -37,7 +37,7 @@ func die(f string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func msg(f string, args ...interface{}) {
+func msg(f string, args ...any) {
 	if !strings.HasSuffix(f, "\n") {
 		f += "\n"
 	}
@@ -45,7 +45,7 @@ func msg(f string, args ...interface{}) {
 	fmt.Printf(f, args...)
 }
 
-func verbose(f string, args ...interface{}) {
+func verbose(f string, args ...any) {
 	if !opts.Verbose {
 		return
 	}

--- a/helpers/prepare-release/main.go
+++ b/helpers/prepare-release/main.go
@@ -43,7 +43,7 @@ func init() {
 	pflag.Parse()
 }
 
-func die(f string, args ...interface{}) {
+func die(f string, args ...any) {
 	if !strings.HasSuffix(f, "\n") {
 		f += "\n"
 	}
@@ -52,7 +52,7 @@ func die(f string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func msg(f string, args ...interface{}) {
+func msg(f string, args ...any) {
 	if !strings.HasSuffix(f, "\n") {
 		f += "\n"
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1669,7 +1669,7 @@ func TestArchiverParent(t *testing.T) {
 			t.Logf("testfs: %v", testFS)
 
 			// check that all files have been read exactly once
-			TestWalkFiles(t, ".", test.src, func(filename string, item interface{}) error {
+			TestWalkFiles(t, ".", test.src, func(filename string, item any) error {
 				file, ok := item.(TestFile)
 				if !ok {
 					return nil
@@ -1696,7 +1696,7 @@ func TestArchiverParent(t *testing.T) {
 			}
 
 			// check that all files still been read exactly once
-			TestWalkFiles(t, ".", test.src, func(filename string, item interface{}) error {
+			TestWalkFiles(t, ".", test.src, func(filename string, item any) error {
 				file, ok := item.(TestFile)
 				if !ok {
 					return nil

--- a/internal/archiver/archiver_unix_test.go
+++ b/internal/archiver/archiver_unix_test.go
@@ -11,11 +11,11 @@ import (
 
 type wrappedFileInfo struct {
 	os.FileInfo
-	sys  interface{}
+	sys  any
 	mode os.FileMode
 }
 
-func (fi wrappedFileInfo) Sys() interface{} {
+func (fi wrappedFileInfo) Sys() any {
 	return fi.sys
 }
 

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -36,7 +36,7 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 }
 
 // TestDir describes a directory structure to create for a test.
-type TestDir map[string]interface{}
+type TestDir map[string]any
 
 func (d TestDir) String() string {
 	return "<Dir>"
@@ -95,7 +95,7 @@ func TestCreateFiles(t testing.TB, target string, dir TestDir) {
 
 // TestWalkFunc is used by TestWalkFiles to traverse the dir. When an error is
 // returned, traversal stops and the surrounding test is marked as failed.
-type TestWalkFunc func(path string, item interface{}) error
+type TestWalkFunc func(path string, item any) error
 
 // TestWalkFiles runs fn for each file/directory in dir, the filename will be
 // constructed with target as the prefix. Symlinks on Windows are ignored.
@@ -134,7 +134,7 @@ func TestEnsureFiles(t testing.TB, target string, dir TestDir) {
 	pathsChecked := make(map[string]struct{})
 
 	// first, test that all items are there
-	TestWalkFiles(t, target, dir, func(path string, item interface{}) error {
+	TestWalkFiles(t, target, dir, func(path string, item any) error {
 		// ignore symlinks on Windows
 		if _, ok := item.(TestSymlink); ok && runtime.GOOS == "windows" {
 			// mark paths and parents as checked

--- a/internal/archiver/testing_test.go
+++ b/internal/archiver/testing_test.go
@@ -30,30 +30,30 @@ func (t *MockT) Fail() {
 }
 
 // Fatal is equivalent to Log followed by FailNow.
-func (t *MockT) Fatal(args ...interface{}) {
+func (t *MockT) Fatal(args ...any) {
 	t.T.Logf("MockT Fatal called with %v", args)
 	t.HasFailed = true
 }
 
 // Fatalf is equivalent to Logf followed by FailNow.
-func (t *MockT) Fatalf(msg string, args ...interface{}) {
+func (t *MockT) Fatalf(msg string, args ...any) {
 	t.T.Logf("MockT Fatal called: "+msg, args...)
 	t.HasFailed = true
 }
 
 // Error is equivalent to Log followed by Fail.
-func (t *MockT) Error(args ...interface{}) {
+func (t *MockT) Error(args ...any) {
 	t.T.Logf("MockT Error called with %v", args)
 	t.HasFailed = true
 }
 
 // Errorf is equivalent to Logf followed by Fail.
-func (t *MockT) Errorf(msg string, args ...interface{}) {
+func (t *MockT) Errorf(msg string, args ...any) {
 	t.T.Logf("MockT Error called: "+msg, args...)
 	t.HasFailed = true
 }
 
-func createFilesAt(t testing.TB, targetdir string, files map[string]interface{}) {
+func createFilesAt(t testing.TB, targetdir string, files map[string]any) {
 	for name, item := range files {
 		target := filepath.Join(targetdir, filepath.FromSlash(name))
 		err := fs.MkdirAll(filepath.Dir(target), 0700)
@@ -83,7 +83,7 @@ func createFilesAt(t testing.TB, targetdir string, files map[string]interface{})
 func TestTestCreateFiles(t *testing.T) {
 	var tests = []struct {
 		dir   TestDir
-		files map[string]interface{}
+		files map[string]any
 	}{
 		{
 			dir: TestDir{
@@ -97,7 +97,7 @@ func TestTestCreateFiles(t *testing.T) {
 					},
 				},
 			},
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo":             TestFile{Content: "foo"},
 				"subdir":          TestDir{},
 				"subdir/subfile":  TestFile{Content: "bar"},
@@ -211,7 +211,7 @@ func TestTestWalkFiles(t *testing.T) {
 			got := make(map[string]string)
 
 			TestCreateFiles(t, tempdir, test.dir)
-			TestWalkFiles(t, tempdir, test.dir, func(path string, item interface{}) error {
+			TestWalkFiles(t, tempdir, test.dir, func(path string, item any) error {
 				p, err := filepath.Rel(tempdir, path)
 				if err != nil {
 					return err
@@ -231,12 +231,12 @@ func TestTestWalkFiles(t *testing.T) {
 func TestTestEnsureFiles(t *testing.T) {
 	var tests = []struct {
 		expectFailure bool
-		files         map[string]interface{}
+		files         map[string]any
 		want          TestDir
 		unixOnly      bool
 	}{
 		{
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo":            TestFile{Content: "foo"},
 				"subdir/subfile": TestFile{Content: "bar"},
 				"x/y/link":       TestSymlink{Target: "../../foo"},
@@ -255,7 +255,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -267,7 +267,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo":            TestFile{Content: "foo"},
 				"subdir/subfile": TestFile{Content: "bar"},
 			},
@@ -277,7 +277,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "xxx"},
 			},
 			want: TestDir{
@@ -286,7 +286,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestSymlink{Target: "/xxx"},
 			},
 			want: TestDir{
@@ -296,7 +296,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		{
 			expectFailure: true,
 			unixOnly:      true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -306,7 +306,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		{
 			expectFailure: true,
 			unixOnly:      true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestSymlink{Target: "xxx"},
 			},
 			want: TestDir{
@@ -315,7 +315,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestDir{
 					"foo": TestFile{Content: "foo"},
 				},
@@ -326,7 +326,7 @@ func TestTestEnsureFiles(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -366,12 +366,12 @@ func TestTestEnsureFiles(t *testing.T) {
 func TestTestEnsureSnapshot(t *testing.T) {
 	var tests = []struct {
 		expectFailure bool
-		files         map[string]interface{}
+		files         map[string]any
 		want          TestDir
 		unixOnly      bool
 	}{
 		{
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo":                                TestFile{Content: "foo"},
 				filepath.FromSlash("subdir/subfile"): TestFile{Content: "bar"},
 				filepath.FromSlash("x/y/link"):       TestSymlink{Target: filepath.FromSlash("../../foo")},
@@ -392,7 +392,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -403,7 +403,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 				"bar": TestFile{Content: "bar"},
 			},
@@ -415,7 +415,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -427,7 +427,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{
@@ -440,7 +440,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestSymlink{Target: filepath.FromSlash("x/y/z")},
 			},
 			want: TestDir{
@@ -452,7 +452,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		{
 			expectFailure: true,
 			unixOnly:      true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestSymlink{Target: filepath.FromSlash("x/y/z")},
 			},
 			want: TestDir{
@@ -463,7 +463,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 		},
 		{
 			expectFailure: true,
-			files: map[string]interface{}{
+			files: map[string]any{
 				"foo": TestFile{Content: "foo"},
 			},
 			want: TestDir{

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -29,7 +29,7 @@ func newAzureTestSuite(t testing.TB) *test.Suite {
 		MinimalData: true,
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			azcfg, err := azure.ParseConfig(os.Getenv("RESTIC_TEST_AZURE_REPOSITORY"))
 			if err != nil {
 				return nil, err
@@ -43,7 +43,7 @@ func newAzureTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(azure.Config)
 
 			be, err := azure.Create(cfg, tr)
@@ -64,14 +64,14 @@ func newAzureTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(azure.Config)
 
 			return azure.Open(cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(azure.Config)
 
 			be, err := azure.Open(cfg, tr)

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -33,7 +33,7 @@ func init() {
 
 // ParseConfig parses the string s and extracts the azure config. The
 // configuration format is azure:containerName:/[prefix].
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "azure:") {
 		return nil, errors.New("azure: invalid format")
 	}

--- a/internal/backend/b2/b2_test.go
+++ b/internal/backend/b2/b2_test.go
@@ -30,7 +30,7 @@ func newB2TestSuite(t testing.TB) *test.Suite {
 		WaitForDelayedRemoval: 10 * time.Second,
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			b2cfg, err := b2.ParseConfig(os.Getenv("RESTIC_TEST_B2_REPOSITORY"))
 			if err != nil {
 				return nil, err
@@ -44,19 +44,19 @@ func newB2TestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(b2.Config)
 			return b2.Create(context.Background(), cfg, tr)
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(b2.Config)
 			return b2.Open(context.Background(), cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(b2.Config)
 			be, err := b2.Open(context.Background(), cfg, tr)
 			if err != nil {

--- a/internal/backend/b2/config.go
+++ b/internal/backend/b2/config.go
@@ -58,7 +58,7 @@ func checkBucketName(name string) error {
 // ParseConfig parses the string s and extracts the b2 config. The supported
 // configuration format is b2:bucketname/prefix. If no prefix is given the
 // prefix "restic" will be used.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "b2:") {
 		return nil, errors.New("invalid format, want: b2:bucket-name[:path]")
 	}

--- a/internal/backend/gs/config.go
+++ b/internal/backend/gs/config.go
@@ -32,7 +32,7 @@ func init() {
 
 // ParseConfig parses the string s and extracts the gcs config. The
 // supported configuration format is gs:bucketName:/[prefix].
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "gs:") {
 		return nil, errors.New("gs: invalid format")
 	}

--- a/internal/backend/gs/gs_test.go
+++ b/internal/backend/gs/gs_test.go
@@ -26,7 +26,7 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		MinimalData: true,
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			gscfg, err := gs.ParseConfig(os.Getenv("RESTIC_TEST_GS_REPOSITORY"))
 			if err != nil {
 				return nil, err
@@ -39,7 +39,7 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(gs.Config)
 
 			be, err := gs.Create(cfg, tr)
@@ -60,13 +60,13 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(gs.Config)
 			return gs.Open(cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(gs.Config)
 
 			be, err := gs.Open(cfg, tr)

--- a/internal/backend/local/config.go
+++ b/internal/backend/local/config.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 // ParseConfig parses a local backend config.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "local:") {
 		return nil, errors.New(`invalid format, prefix "local" not found`)
 	}

--- a/internal/backend/local/local_test.go
+++ b/internal/backend/local/local_test.go
@@ -16,7 +16,7 @@ import (
 func newTestSuite(t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			dir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-local-")
 			if err != nil {
 				t.Fatal(err)
@@ -32,19 +32,19 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(local.Config)
 			return local.Create(context.TODO(), cfg)
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(local.Config)
 			return local.Open(context.TODO(), cfg)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(local.Config)
 			if !rtest.TestCleanupTempDirs {
 				t.Logf("leaving test backend dir at %v", cfg.Path)

--- a/internal/backend/location/location.go
+++ b/internal/backend/location/location.go
@@ -20,12 +20,12 @@ import (
 // access and (possibly) credentials needed for access.
 type Location struct {
 	Scheme string
-	Config interface{}
+	Config any
 }
 
 type parser struct {
 	scheme        string
-	parse         func(string) (interface{}, error)
+	parse         func(string) (any, error)
 	stripPassword func(string) string
 }
 

--- a/internal/backend/mem/mem_backend_test.go
+++ b/internal/backend/mem/mem_backend_test.go
@@ -18,12 +18,12 @@ type memConfig struct {
 func newTestSuite() *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			return &memConfig{}, nil
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(cfg interface{}) (restic.Backend, error) {
+		Create: func(cfg any) (restic.Backend, error) {
 			c := cfg.(*memConfig)
 			if c.be != nil {
 				ok, err := c.be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
@@ -41,7 +41,7 @@ func newTestSuite() *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(cfg interface{}) (restic.Backend, error) {
+		Open: func(cfg any) (restic.Backend, error) {
 			c := cfg.(*memConfig)
 			if c.be == nil {
 				c.be = mem.New()
@@ -50,7 +50,7 @@ func newTestSuite() *test.Suite {
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(cfg interface{}) error {
+		Cleanup: func(cfg any) error {
 			// no cleanup needed
 			return nil
 		},

--- a/internal/backend/rclone/backend_test.go
+++ b/internal/backend/rclone/backend_test.go
@@ -17,7 +17,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			t.Logf("use backend at %v", dir)
 			cfg := rclone.NewConfig()
 			cfg.Remote = dir
@@ -25,7 +25,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			t.Logf("Create()")
 			cfg := config.(rclone.Config)
 			be, err := rclone.Create(context.TODO(), cfg)
@@ -38,14 +38,14 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			t.Logf("Open()")
 			cfg := config.(rclone.Config)
 			return rclone.Open(cfg, nil)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			t.Logf("cleanup dir %v", dir)
 			cleanup()
 			return nil

--- a/internal/backend/rclone/config.go
+++ b/internal/backend/rclone/config.go
@@ -34,7 +34,7 @@ func NewConfig() Config {
 }
 
 // ParseConfig parses the string s and extracts the remote server URL.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "rclone:") {
 		return nil, errors.New("invalid rclone backend specification")
 	}

--- a/internal/backend/rest/config.go
+++ b/internal/backend/rest/config.go
@@ -26,7 +26,7 @@ func NewConfig() Config {
 }
 
 // ParseConfig parses the string s and extracts the REST server URL.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	if !strings.HasPrefix(s, "rest:") {
 		return nil, errors.New("invalid REST backend specification")
 	}

--- a/internal/backend/rest/rest_test.go
+++ b/internal/backend/rest/rest_test.go
@@ -77,26 +77,26 @@ func newTestSuite(ctx context.Context, t testing.TB, url *url.URL, minimalData b
 		MinimalData: minimalData,
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			cfg := rest.NewConfig()
 			cfg.URL = url
 			return cfg, nil
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(rest.Config)
 			return rest.Create(context.TODO(), cfg, tr)
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(rest.Config)
 			return rest.Open(cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			return nil
 		},
 	}

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -44,7 +44,7 @@ func init() {
 // supported configuration formats are s3://host/bucketname/prefix and
 // s3:host/bucketname/prefix. The host can also be a valid s3 region
 // name. If no prefix is given the prefix "restic" will be used.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	switch {
 	case strings.HasPrefix(s, "s3:http"):
 		// assume that a URL has been specified, parse it and
@@ -74,7 +74,7 @@ func ParseConfig(s string) (interface{}, error) {
 	return createConfig(path[0], path[1:], false)
 }
 
-func createConfig(endpoint string, p []string, useHTTP bool) (interface{}, error) {
+func createConfig(endpoint string, p []string, useHTTP bool) (any, error) {
 	if len(p) < 1 {
 		return nil, errors.New("s3: invalid format, host/region or bucket name not found")
 	}

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -196,7 +196,7 @@ func (fi *fileInfo) Size() int64        { return fi.size }    // length in bytes
 func (fi *fileInfo) Mode() os.FileMode  { return fi.mode }    // file mode bits
 func (fi *fileInfo) ModTime() time.Time { return fi.modTime } // modification time
 func (fi *fileInfo) IsDir() bool        { return fi.isDir }   // abbreviation for Mode().IsDir()
-func (fi *fileInfo) Sys() interface{}   { return nil }        // underlying data source (can return nil)
+func (fi *fileInfo) Sys() any           { return nil }        // underlying data source (can return nil)
 
 // ReadDir returns the entries for a directory.
 func (be *Backend) ReadDir(ctx context.Context, dir string) (list []os.FileInfo, err error) {

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -129,7 +129,7 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			cfg := MinioTestConfig{}
 
 			cfg.tempdir, cfg.removeTempdir = rtest.TempDir(t)
@@ -147,7 +147,7 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(MinioTestConfig)
 
 			be, err := createS3(t, cfg, tr)
@@ -168,13 +168,13 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(MinioTestConfig)
 			return s3.Open(ctx, cfg.Config, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(MinioTestConfig)
 			if cfg.stopServer != nil {
 				cfg.stopServer()
@@ -232,7 +232,7 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 		MinimalData: true,
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			s3cfg, err := s3.ParseConfig(os.Getenv("RESTIC_TEST_S3_REPOSITORY"))
 			if err != nil {
 				return nil, err
@@ -246,7 +246,7 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(s3.Config)
 
 			be, err := s3.Create(context.TODO(), cfg, tr)
@@ -267,13 +267,13 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(s3.Config)
 			return s3.Open(context.TODO(), cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(s3.Config)
 
 			be, err := s3.Open(context.TODO(), cfg, tr)

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -35,7 +35,7 @@ func init() {
 // and sftp:user@host:directory.  The directory will be path Cleaned and can
 // be an absolute path if it starts with a '/' (e.g.
 // sftp://user@host//absolute and sftp:user@host:/absolute).
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	var user, host, port, dir string
 	switch {
 	case strings.HasPrefix(s, "sftp://"):

--- a/internal/backend/sftp/sftp_test.go
+++ b/internal/backend/sftp/sftp_test.go
@@ -33,7 +33,7 @@ var sftpServer = findSFTPServerBinary()
 func newTestSuite(t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			dir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-sftp-")
 			if err != nil {
 				t.Fatal(err)
@@ -50,19 +50,19 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(sftp.Config)
 			return sftp.Create(context.TODO(), cfg)
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(sftp.Config)
 			return sftp.Open(context.TODO(), cfg)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(sftp.Config)
 			if !rtest.TestCleanupTempDirs {
 				t.Logf("leaving test backend dir at %v", cfg.Path)

--- a/internal/backend/swift/config.go
+++ b/internal/backend/swift/config.go
@@ -50,7 +50,7 @@ func NewConfig() Config {
 }
 
 // ParseConfig parses the string s and extract swift's container name and prefix.
-func ParseConfig(s string) (interface{}, error) {
+func ParseConfig(s string) (any, error) {
 	data := strings.SplitN(s, ":", 3)
 	if len(data) != 3 {
 		return nil, errors.New("invalid URL, expected: swift:container-name:/[prefix]")
@@ -78,7 +78,7 @@ func ParseConfig(s string) (interface{}, error) {
 }
 
 // ApplyEnvironment saves values from the environment to the config.
-func ApplyEnvironment(prefix string, cfg interface{}) error {
+func ApplyEnvironment(prefix string, cfg any) error {
 	c := cfg.(*Config)
 	for _, val := range []struct {
 		s   *string

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -265,7 +265,7 @@ func (be *beSwift) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	prefix += "/"
 
 	err := be.conn.ObjectsWalk(ctx, be.container, &swift.ObjectsOpts{Prefix: prefix},
-		func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
+		func(ctx context.Context, opts *swift.ObjectsOpts) (any, error) {
 			be.sem.GetToken()
 			newObjects, err := be.conn.Objects(ctx, be.container, opts)
 			be.sem.ReleaseToken()

--- a/internal/backend/swift/swift_test.go
+++ b/internal/backend/swift/swift_test.go
@@ -42,7 +42,7 @@ func newSwiftTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			swiftcfg, err := swift.ParseConfig(os.Getenv("RESTIC_TEST_SWIFT"))
 			if err != nil {
 				return nil, err
@@ -58,7 +58,7 @@ func newSwiftTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(config interface{}) (restic.Backend, error) {
+		Create: func(config any) (restic.Backend, error) {
 			cfg := config.(swift.Config)
 
 			be, err := swift.Open(context.TODO(), cfg, tr)
@@ -79,13 +79,13 @@ func newSwiftTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(config interface{}) (restic.Backend, error) {
+		Open: func(config any) (restic.Backend, error) {
 			cfg := config.(swift.Config)
 			return swift.Open(context.TODO(), cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(config interface{}) error {
+		Cleanup: func(config any) error {
 			cfg := config.(swift.Config)
 
 			be, err := swift.Open(context.TODO(), cfg, tr)

--- a/internal/backend/test/suite.go
+++ b/internal/backend/test/suite.go
@@ -13,19 +13,19 @@ import (
 // Suite implements a test suite for restic backends.
 type Suite struct {
 	// Config should be used to configure the backend.
-	Config interface{}
+	Config any
 
 	// NewConfig returns a config for a new temporary backend that will be used in tests.
-	NewConfig func() (interface{}, error)
+	NewConfig func() (any, error)
 
 	// CreateFn is a function that creates a temporary repository for the tests.
-	Create func(cfg interface{}) (restic.Backend, error)
+	Create func(cfg any) (restic.Backend, error)
 
 	// OpenFn is a function that opens a previously created temporary repository.
-	Open func(cfg interface{}) (restic.Backend, error)
+	Open func(cfg any) (restic.Backend, error)
 
 	// CleanupFn removes data created during the tests.
-	Cleanup func(cfg interface{}) error
+	Cleanup func(cfg any) error
 
 	// MinimalData instructs the tests to not use excessive data.
 	MinimalData bool

--- a/internal/backend/test/tests_test.go
+++ b/internal/backend/test/tests_test.go
@@ -18,12 +18,12 @@ type memConfig struct {
 func newTestSuite(t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
-		NewConfig: func() (interface{}, error) {
+		NewConfig: func() (any, error) {
 			return &memConfig{}, nil
 		},
 
 		// CreateFn is a function that creates a temporary repository for the tests.
-		Create: func(cfg interface{}) (restic.Backend, error) {
+		Create: func(cfg any) (restic.Backend, error) {
 			c := cfg.(*memConfig)
 			if c.be != nil {
 				ok, err := c.be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
@@ -41,7 +41,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
-		Open: func(cfg interface{}) (restic.Backend, error) {
+		Open: func(cfg any) (restic.Backend, error) {
 			c := cfg.(*memConfig)
 			if c.be == nil {
 				c.be = mem.New()
@@ -50,7 +50,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 		},
 
 		// CleanupFn removes data created during the tests.
-		Cleanup: func(cfg interface{}) error {
+		Cleanup: func(cfg any) error {
 			// no cleanup needed
 			return nil
 		},

--- a/internal/bloblru/cache.go
+++ b/internal/bloblru/cache.go
@@ -55,7 +55,7 @@ func (c *Cache) Add(id restic.ID, blob []byte) (old []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var key interface{} = id
+	var key any = id
 
 	if c.c.Contains(key) { // Doesn't update the recency list.
 		return
@@ -89,7 +89,7 @@ func (c *Cache) Get(id restic.ID) ([]byte, bool) {
 	return blob, ok
 }
 
-func (c *Cache) evict(key, value interface{}) {
+func (c *Cache) evict(key, value any) {
 	blob := value.([]byte)
 	debug.Log("bloblru.Cache: evict %v, %d bytes", key, cap(blob))
 	c.free += cap(blob) + overhead

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -162,7 +162,7 @@ func checkFilter(filter map[string]bool, key string) bool {
 }
 
 // Log prints a message to the debug log (if debug is enabled).
-func Log(f string, args ...interface{}) {
+func Log(f string, args ...any) {
 	if !opts.isEnabled {
 		return
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -52,6 +52,6 @@ func Cause(err error) error {
 
 // Go 1.13-style error handling.
 
-func As(err error, tgt interface{}) bool { return errors.As(err, tgt) }
+func As(err error, tgt any) bool { return errors.As(err, tgt) }
 
 func Is(x, y error) bool { return errors.Is(x, y) }

--- a/internal/errors/fatal.go
+++ b/internal/errors/fatal.go
@@ -35,6 +35,6 @@ func Fatal(s string) error {
 }
 
 // Fatalf returns an error which implements the Fataler interface.
-func Fatalf(s string, data ...interface{}) error {
+func Fatalf(s string, data ...any) error {
 	return Wrap(fatalError(fmt.Sprintf(s, data...)), "Fatal")
 }

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -13,7 +13,7 @@ import (
 type ErrorHandler func(item string, err error) error
 
 // MessageHandler is used to report errors/messages via callbacks.
-type MessageHandler func(msg string, args ...interface{})
+type MessageHandler func(msg string, args ...any)
 
 // LocalVss is a wrapper around the local file system which uses windows volume
 // shadow copy service (VSS) in a transparent way.

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -319,6 +319,6 @@ func (fi fakeFileInfo) IsDir() bool {
 	return fi.mode&os.ModeDir > 0
 }
 
-func (fi fakeFileInfo) Sys() interface{} {
+func (fi fakeFileInfo) Sys() any {
 	return nil
 }

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -991,8 +991,8 @@ func findVssProc(procName string) (*windows.LazyProc, error) {
 }
 
 // queryInterface is a wrapper around the windows QueryInterface api.
-func queryInterface(oleIUnknown *ole.IUnknown, guid *ole.GUID) (*interface{}, error) {
-	var ivss *interface{}
+func queryInterface(oleIUnknown *ole.IUnknown, guid *ole.GUID) (*any, error) {
+	var ivss *any
 
 	result, _, _ := syscall.Syscall(oleIUnknown.VTable().QueryInterface, 3,
 		uintptr(unsafe.Pointer(oleIUnknown)), uintptr(unsafe.Pointer(guid)),

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -16,7 +16,7 @@ type Options map[string]string
 var opts []Help
 
 // Register allows registering options so that they can be listed with List.
-func Register(ns string, cfg interface{}) {
+func Register(ns string, cfg any) {
 	opts = appendAllOptions(opts, ns, cfg)
 }
 
@@ -28,7 +28,7 @@ func List() (list []Help) {
 }
 
 // appendAllOptions appends all options in cfg to opts, sorted by namespace.
-func appendAllOptions(opts []Help, ns string, cfg interface{}) []Help {
+func appendAllOptions(opts []Help, ns string, cfg any) []Help {
 	for _, opt := range listOptions(cfg) {
 		opt.Namespace = ns
 		opts = append(opts, opt)
@@ -39,7 +39,7 @@ func appendAllOptions(opts []Help, ns string, cfg interface{}) []Help {
 }
 
 // listOptions returns a list of options of cfg.
-func listOptions(cfg interface{}) (opts []Help) {
+func listOptions(cfg any) (opts []Help) {
 	// resolve indirection if cfg is a pointer
 	v := reflect.Indirect(reflect.ValueOf(cfg))
 
@@ -149,7 +149,7 @@ func (o Options) Extract(ns string) Options {
 
 // Apply sets the options on dst via reflection, using the struct tag `option`.
 // The namespace argument (ns) is only used for error messages.
-func (o Options) Apply(ns string, dst interface{}) error {
+func (o Options) Apply(ns string, dst any) error {
 	v := reflect.ValueOf(dst).Elem()
 
 	fields := make(map[string]reflect.StructField)

--- a/internal/options/options_test.go
+++ b/internal/options/options_test.go
@@ -247,7 +247,7 @@ func TestListOptions(t *testing.T) {
 	}{}
 
 	tests := []struct {
-		cfg  interface{}
+		cfg  any
 		opts []Help
 	}{
 		{
@@ -298,11 +298,11 @@ func TestListOptions(t *testing.T) {
 
 func TestAppendAllOptions(t *testing.T) {
 	tests := []struct {
-		cfgs map[string]interface{}
+		cfgs map[string]any
 		opts []Help
 	}{
 		{
-			map[string]interface{}{
+			map[string]any{
 				"local": struct {
 					Foo string `option:"foo" help:"bar text help"`
 				}{},

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -23,7 +23,7 @@ var testKDFParams = crypto.Params{
 }
 
 type logger interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // TestUseLowSecurityKDFParameters configures low-security KDF parameters for testing.

--- a/internal/restic/config.go
+++ b/internal/restic/config.go
@@ -27,7 +27,7 @@ const StableRepoVersion = 2
 
 // JSONUnpackedLoader loads unpacked JSON.
 type JSONUnpackedLoader interface {
-	LoadJSONUnpacked(context.Context, FileType, ID, interface{}) error
+	LoadJSONUnpacked(context.Context, FileType, ID, any) error
 }
 
 // CreateConfig creates a config file with a randomly selected polynomial and

--- a/internal/restic/json.go
+++ b/internal/restic/json.go
@@ -10,7 +10,7 @@ import (
 
 // LoadJSONUnpacked decrypts the data and afterwards calls json.Unmarshal on
 // the item.
-func LoadJSONUnpacked(ctx context.Context, repo LoaderUnpacked, t FileType, id ID, item interface{}) (err error) {
+func LoadJSONUnpacked(ctx context.Context, repo LoaderUnpacked, t FileType, id ID, item any) (err error) {
 	buf, err := repo.LoadUnpacked(ctx, t, id, nil)
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func LoadJSONUnpacked(ctx context.Context, repo LoaderUnpacked, t FileType, id I
 
 // SaveJSONUnpacked serialises item as JSON and encrypts and saves it in the
 // backend as type t, without a pack. It returns the storage hash.
-func SaveJSONUnpacked(ctx context.Context, repo SaverUnpacked, t FileType, item interface{}) (ID, error) {
+func SaveJSONUnpacked(ctx context.Context, repo SaverUnpacked, t FileType, item any) (ID, error) {
 	debug.Log("save new blob %v", t)
 	plaintext, err := json.Marshal(item)
 	if err != nil {

--- a/internal/restic/node_unix.go
+++ b/internal/restic/node_unix.go
@@ -14,7 +14,7 @@ func lchown(name string, uid, gid int) error {
 
 type statT syscall.Stat_t
 
-func toStatT(i interface{}) (*statT, bool) {
+func toStatT(i any) (*statT, bool) {
 	s, ok := i.(*syscall.Stat_t)
 	if ok && s != nil {
 		return (*statT)(s), true

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -38,7 +38,7 @@ func Setxattr(path, name string, data []byte) error {
 
 type statT syscall.Win32FileAttributeData
 
-func toStatT(i interface{}) (*statT, bool) {
+func toStatT(i any) (*statT, bool) {
 	s, ok := i.(*syscall.Win32FileAttributeData)
 	if ok && s != nil {
 		return (*statT)(s), true

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -28,8 +28,8 @@ type fileInfo struct {
 	lock       sync.Mutex
 	inProgress bool
 	size       int64
-	location   string      // file on local filesystem relative to restorer basedir
-	blobs      interface{} // blobs of the file
+	location   string // file on local filesystem relative to restorer basedir
+	blobs      any    // blobs of the file
 }
 
 type fileBlobInfo struct {

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type Node interface{}
+type Node any
 
 type Snapshot struct {
 	Nodes map[string]Node

--- a/internal/selfupdate/download.go
+++ b/internal/selfupdate/download.go
@@ -40,7 +40,7 @@ func findHash(buf []byte, filename string) (hash []byte, err error) {
 	return nil, fmt.Errorf("hash for file %v not found", filename)
 }
 
-func extractToFile(buf []byte, filename, target string, printf func(string, ...interface{})) error {
+func extractToFile(buf []byte, filename, target string, printf func(string, ...any)) error {
 	var rd io.Reader = bytes.NewReader(buf)
 	switch filepath.Ext(filename) {
 	case ".bz2":
@@ -110,9 +110,9 @@ func extractToFile(buf []byte, filename, target string, printf func(string, ...i
 // DownloadLatestStableRelease downloads the latest stable released version of
 // restic and saves it to target. It returns the version string for the newest
 // version. The function printf is used to print progress information.
-func DownloadLatestStableRelease(ctx context.Context, target, currentVersion string, printf func(string, ...interface{})) (version string, err error) {
+func DownloadLatestStableRelease(ctx context.Context, target, currentVersion string, printf func(string, ...any)) (version string, err error) {
 	if printf == nil {
-		printf = func(string, ...interface{}) {}
+		printf = func(string, ...any) {}
 	}
 
 	printf("find latest release of restic at GitHub\n")

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -143,7 +143,7 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 	return buf, nil
 }
 
-func getGithubDataFile(ctx context.Context, assets []Asset, suffix string, printf func(string, ...interface{})) (filename string, data []byte, err error) {
+func getGithubDataFile(ctx context.Context, assets []Asset, suffix string, printf func(string, ...any)) (filename string, data []byte, err error) {
 	var url string
 	for _, a := range assets {
 		if strings.HasSuffix(a.Name, suffix) {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -19,10 +19,10 @@ import (
 )
 
 // Assert fails the test if the condition is false.
-func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+func Assert(tb testing.TB, condition bool, msg string, v ...any) {
 	if !condition {
 		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]any{filepath.Base(file), line}, v...)...)
 		tb.FailNow()
 	}
 }
@@ -52,7 +52,7 @@ func OKs(tb testing.TB, errs []error) {
 }
 
 // Equals fails the test if exp is not equal to act.
-func Equals(tb testing.TB, exp, act interface{}) {
+func Equals(tb testing.TB, exp, act any) {
 	if !reflect.DeepEqual(exp, act) {
 		_, file, line, _ := runtime.Caller(1)
 		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -34,7 +34,7 @@ func NewJSONProgress(term *termstatus.Terminal, verbosity uint) *JSONProgress {
 	}
 }
 
-func toJSONString(status interface{}) string {
+func toJSONString(status any) string {
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(status)
 	if err != nil {
@@ -43,11 +43,11 @@ func toJSONString(status interface{}) string {
 	return buf.String()
 }
 
-func (b *JSONProgress) print(status interface{}) {
+func (b *JSONProgress) print(status any) {
 	b.term.Print(toJSONString(status))
 }
 
-func (b *JSONProgress) error(status interface{}) {
+func (b *JSONProgress) error(status any) {
 	b.term.Error(toJSONString(status))
 }
 

--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -24,10 +24,10 @@ type ProgressPrinter interface {
 	Stdout() io.WriteCloser
 	Stderr() io.WriteCloser
 
-	E(msg string, args ...interface{})
-	P(msg string, args ...interface{})
-	V(msg string, args ...interface{})
-	VV(msg string, args ...interface{})
+	E(msg string, args ...any)
+	P(msg string, args ...any)
+	V(msg string, args ...any)
+	VV(msg string, args ...any)
 }
 
 type Counter struct {

--- a/internal/ui/message.go
+++ b/internal/ui/message.go
@@ -18,27 +18,27 @@ func NewMessage(term *termstatus.Terminal, verbosity uint) *Message {
 }
 
 // E reports an error
-func (m *Message) E(msg string, args ...interface{}) {
+func (m *Message) E(msg string, args ...any) {
 	m.term.Errorf(msg, args...)
 }
 
 // P prints a message if verbosity >= 1, this is used for normal messages which
 // are not errors.
-func (m *Message) P(msg string, args ...interface{}) {
+func (m *Message) P(msg string, args ...any) {
 	if m.v >= 1 {
 		m.term.Printf(msg, args...)
 	}
 }
 
 // V prints a message if verbosity >= 2, this is used for verbose messages.
-func (m *Message) V(msg string, args ...interface{}) {
+func (m *Message) V(msg string, args ...any) {
 	if m.v >= 2 {
 		m.term.Printf(msg, args...)
 	}
 }
 
 // VV prints a message if verbosity >= 3, this is used for debug messages.
-func (m *Message) VV(msg string, args ...interface{}) {
+func (m *Message) VV(msg string, args ...any) {
 	if m.v >= 3 {
 		m.term.Printf(msg, args...)
 	}

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -12,7 +12,7 @@ import (
 type Table struct {
 	columns   []string
 	templates []*template.Template
-	data      []interface{}
+	data      []any
 	footer    []string
 
 	CellSeparator  string
@@ -57,7 +57,7 @@ func (t *Table) AddColumn(header, format string) {
 }
 
 // AddRow adds a new row to the table, which is filled with data.
-func (t *Table) AddRow(data interface{}) {
+func (t *Table) AddRow(data any) {
 	t.data = append(t.data, data)
 }
 

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -263,7 +263,7 @@ func (t *Terminal) Print(line string) {
 }
 
 // Printf uses fmt.Sprintf to write a line to the terminal.
-func (t *Terminal) Printf(msg string, args ...interface{}) {
+func (t *Terminal) Printf(msg string, args ...any) {
 	s := fmt.Sprintf(msg, args...)
 	t.Print(s)
 }
@@ -274,7 +274,7 @@ func (t *Terminal) Error(line string) {
 }
 
 // Errorf uses fmt.Sprintf to write an error line to the terminal.
-func (t *Terminal) Errorf(msg string, args ...interface{}) {
+func (t *Terminal) Errorf(msg string, args ...any) {
 	s := fmt.Sprintf(msg, args...)
 	t.Error(s)
 }

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestTree is used to construct a list of trees for testing the walker.
-type TestTree map[string]interface{}
+type TestTree map[string]any
 
 // TestNode is used to test the walker.
 type TestFile struct{}


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)